### PR TITLE
Fixes #1 pusher_1.default is not a constructor

### DIFF
--- a/src/pusher.service.ts
+++ b/src/pusher.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Logger } from '@nestjs/common'
-import Pusher from 'pusher'
+import * as Pusher from 'pusher'
 
 @Injectable()
 export class PusherService {


### PR DESCRIPTION
@underfisk  I just changed one line of code. But I am assuming you would also need to update the version to `0.0.5` to release an update. Can you also update the Pusher library version to latest (`^5.0.1`) in that update? I can send you another PR for that.