### PR TITLE
Fixes #7: Match peer and dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
     "testEnvironment": "node"
   },
   "peerDependencies": {
-    "@nestjs/common": "^7.5.1",
-    "@nestjs/core": "^7.5.1",
+    "@nestjs/common": "^8.4.4",
+    "@nestjs/core": "^8.4.4",
     "pusher": "^5.0.1"
   }
 }


### PR DESCRIPTION
There was a mismatch of versions in peer and dev dependencies.

This fix will also allow the nestjs-pusher to be used by NestJS v8 projects.
